### PR TITLE
Fixed open mode from w9 to w

### DIFF
--- a/src/NIfTI.jl
+++ b/src/NIfTI.jl
@@ -416,7 +416,7 @@ end
 # Convenience function to write a NIfTI file given a path
 function niwrite(path::AbstractString, vol::NIVolume)
     if split(path,".")[end] == "gz"
-        io = open(path, "w9")
+        io = open(path, "w")
         stream = GzipCompressorStream(io)
         write(stream, vol)
         close(stream)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,3 @@
 [deps]
-GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,11 @@
-using NIfTI, GZip
+using NIfTI, CodecZlib, TranscodingStreams
 using Test
 
 function extractto(gzname, out)
-    open(out, "w") do io
-        gzopen(gzname) do gz
-          write(io, read(gz))
+    open(out, "w") do io_out
+        open(gzname, "r") do io_in
+            gz = GzipDecompressorStream(io_in)
+            write(io_out, read(gz))
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,7 +72,7 @@ cp(WRITE, VERIFY_WRITE)
 # Big endian
 # const BE = "$(tempname()).nii"
 # download("https://nifti.nimh.nih.gov/nifti-1/data/avg152T1_LR_nifti.nii.gz", BE)
-img = niread("data/avg152T1_LR_nifti.nii.gz")
+img = niread(joinpath(dirname(@__FILE__), "data/avg152T1_LR_nifti.nii.gz"))
 @test size(img) == (91,109,91)
 
 GC.gc() # closes mmapped files

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,10 @@ vol = NIVolume()
 niwrite(TEMP_FILE, vol)
 niread(TEMP_FILE)
 
+const TEMP_GZIPPED_FILE = "$(tempname()).nii.gz"
+niwrite(TEMP_GZIPPED_FILE, vol)
+niread(TEMP_GZIPPED_FILE)
+
 # Write and read DT_BINARY
 const BOOL_WRITE = "$(tempname()).nii"
 const BIT_WRITE = "$(tempname()).nii"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,14 +10,16 @@ function extractto(gzname, out)
     end
 end
 
+const TEMP_DIR_NAME = mktempdir()
+
 # single file storage
 const GZIPPED_NII = joinpath(dirname(@__FILE__), "data/example4d.nii.gz")
-const NII = "$(tempname()).nii"
+const NII = joinpath(TEMP_DIR_NAME, "$(tempname()).nii")
 extractto(GZIPPED_NII, NII)
 
 # dual file storage
 const GZIPPED_HDR = joinpath(dirname(@__FILE__), "data/example4d.hdr.gz")
-hdr_stem = tempname()
+hdr_stem = joinpath(TEMP_DIR_NAME, tempname())
 const HDR = "$hdr_stem.hdr"
 const IMG = "$hdr_stem.img"
 extractto(GZIPPED_HDR, HDR)
@@ -44,18 +46,18 @@ end
 @test_throws ErrorException niread(GZIPPED_HDR; mmap=true)
 
 # Test writing
-const TEMP_FILE = "$(tempname()).nii"
+const TEMP_FILE = joinpath(TEMP_DIR_NAME, "$(tempname()).nii")
 vol = NIVolume()
 niwrite(TEMP_FILE, vol)
 niread(TEMP_FILE)
 
-const TEMP_GZIPPED_FILE = "$(tempname()).nii.gz"
+const TEMP_GZIPPED_FILE = joinpath(TEMP_DIR_NAME, "$(tempname()).nii.gz")
 niwrite(TEMP_GZIPPED_FILE, vol)
 niread(TEMP_GZIPPED_FILE)
 
 # Write and read DT_BINARY
-const BOOL_WRITE = "$(tempname()).nii"
-const BIT_WRITE = "$(tempname()).nii"
+const BOOL_WRITE = joinpath(TEMP_DIR_NAME, "$(tempname()).nii")
+const BIT_WRITE = joinpath(TEMP_DIR_NAME, "$(tempname()).nii")
 mask = rand(Bool, 3, 5, 7) # Array{Bool}
 mask_bitarray = BitArray(mask) # BitArray
 niwrite(BOOL_WRITE, NIVolume(mask))
@@ -64,8 +66,8 @@ niwrite(BIT_WRITE, NIVolume(mask_bitarray))
 @test niread(BIT_WRITE).raw == mask_bitarray
 
 # Open mmaped file for reading and writing
-const WRITE = "$(tempname()).nii"
-const VERIFY_WRITE = "$(tempname()).nii"
+const WRITE = joinpath(TEMP_DIR_NAME, "$(tempname()).nii")
+const VERIFY_WRITE = joinpath(TEMP_DIR_NAME, "$(tempname()).nii")
 cp(NII, WRITE)
 img = niread(WRITE; mmap=true, mode="r+")
 img.raw[1,1,1,1] = 5
@@ -81,14 +83,4 @@ img = niread(joinpath(dirname(@__FILE__), "data/avg152T1_LR_nifti.nii.gz"))
 @test size(img) == (91,109,91)
 
 GC.gc() # closes mmapped files
-# Clean up
-rm(NII)
-rm(HDR)
-rm(IMG)
-rm(TEMP_FILE)
-rm(WRITE)
-rm(VERIFY_WRITE)
-rm(BOOL_WRITE)
-rm(BIT_WRITE)
-# rm(BE)
 


### PR DESCRIPTION
When changing from GZip to CodecZlib the gzopen() method was replaced with open(), but the mode is still "w9". The gzopen() accepts a compression level number in the specified mode, but open() does not. Therefor I changed it to "w". 

Fix for Issue #47