### PR TITLE
Assert that extension size is divisible by 16

### DIFF
--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -137,7 +137,7 @@ Int32). Therefore, `8 + sizeof(ex.edata)` should be divisible by 16.
 """
 function esize(ex::NIfTIExtension)
     ret = 8 + length(ex.edata)
-    @assert ret%16 != 0 "NIfTIExtension has innapropriate size. See docstrings for more details."
+    @assert ret%16 == 0 "NIfTIExtension has innapropriate size. See docstrings for more details."
     return ret
 end
 


### PR DESCRIPTION
The current implementation of `esize` makes an `@assert` check that the size is _not_ divisible by 16, which I believe is the opposite of what is intended.

Minimal example:

    dset = niread(fname)
    ex = dset.extensions[1]
    NIfTI.esize(ex)

`AssertionError: NIfTIExtension has innapropriate size. See docstrings for more details.`