### PR TITLE
Update Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
 CodecZlib = "0.7"
-MappedArrays = "0.3"
+MappedArrays = "0.3,0.4"
 TranscodingStreams = "0.9"
 julia = "1.3"
 


### PR DESCRIPTION
Add compat for MappedArrays v0.4

At the moment, other packages are blocked from updating when NIfTI is a dependency (e.g. HistogramThresholds.jl)

A quick test on my machine had no problems with MappedArrays 0.4