### PR TITLE
DATA SCALING only done when `scl_slope != 0`.

### DIFF
--- a/src/NIfTI.jl
+++ b/src/NIfTI.jl
@@ -283,7 +283,8 @@ end
 
 # Allow file to be indexed like an array, but with indices yielding scaled data
 @inline getindex(f::NIVolume{T}, idx::Vararg{Int}) where {T} =
-    getindex(f.raw, idx...,) * f.header.scl_slope + f.header.scl_inter
+    f.header.scl_slope == zero(T) ? getindex(f.raw, idx...,) :
+        getindex(f.raw, idx...,) * f.header.scl_slope + f.header.scl_inter
 
 add1(x::Union{AbstractArray{T},T}) where {T<:Integer} = x + 1
 add1(::Colon) = Colon()


### PR DESCRIPTION
As @kleinschmidt mentioned in #14, "slope/intercept should be used for nonzero slope", and only for nonzero.

A novice would 100% use ```nii_slice=niread(" my_niftifile.nii.gz ")[x,:,:]``` to read the "true" voxel value in a file.
In the [code implementation](https://github.com/JuliaNeuroscience/NIfTI.jl/blob/3ca7b1732305d47aa18a7e917369ccc8ba8d1a2d/src/NIfTI.jl#L286), DATA SCALING is always done by default, which seems quite reasonable.

Let's consider the following:
* In some nii headers, `float scl_slope` will be set to `0` to indicate that "true" voxel is stored in the array Value. This is in [NifTI1.h](https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h) defined.

 
At this point, all voxel values in the file are multiplied by slope and added to inter.
$$y=slope\times x + inter$$

This means that the user is taking a matrix or tensor where all the elements have the same value.
The information in the image was erased without any awareness.

This can lead to a number of serious problems:
* All subsequent algorithms and functions use an erased image
* The code is executed without any warning! Everything seemed perfect.

Therefore, DATA SCALING should only be performed when `slope != 0`.