### PR TITLE
Fix bitpix for UInt8 writes

### DIFF
--- a/src/NIfTI.jl
+++ b/src/NIfTI.jl
@@ -151,7 +151,7 @@ end
 function niupdate(vol::NIVolume{T,N,R}) where {T,N,R}
     vol.header.dim = to_dim_i16(size(vol.raw))
     vol.header.datatype = eltype_to_int16(eltype(R))
-    vol.header.bitpix = nibitpix(T)
+    vol.header.bitpix = nibitpix(eltype(R))
     vol.header.vox_offset = isempty(vol.extensions) ? vol.header.sizeof_hdr + 4 :
                             Int32(mapreduce(esize, +, vol.extensions) + vol.header.sizeof_hdr)
     vol

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,3 +146,22 @@ GC.gc() # closes mmapped files
     0.0, 0.0, -1.0) == (:left, :anterior, :superior)
 
 
+
+@testset "bitpix matches datatype on write" begin
+    # bitpix is the number of bits per voxel as stored, so it has to agree with
+    # datatype, for every type NIfTI.jl can write.
+    dir = mktempdir()
+    expected = Dict(Bool => 1, UInt8 => 8, Int8 => 8, Int16 => 16, UInt16 => 16,
+                    Int32 => 32, UInt32 => 32, Int64 => 64, UInt64 => 64,
+                    Float32 => 32, Float64 => 64, ComplexF32 => 64, ComplexF64 => 128)
+    for (T, bits) in expected
+        img = T <: Complex ? rand(T, 4, 4, 2) :
+              T === Bool ? rand(Bool, 4, 4, 2) : T.(rand(0:5, 4, 4, 2))
+        path = joinpath(dir, "bitpix_$T.nii")
+        niwrite(path, NIVolume(img))
+        vol = niread(path)
+        @test vol.header.bitpix == bits
+        @test eltype(vol.raw) === T
+        @test vol.raw == img
+    end
+end


### PR DESCRIPTION
## Summary
Fixes #85

UInt8 and other short headers now use the correct bitpix in the header.

The new test covers all data types and fails on the old version.


## Details
bitpix is the number of bits per voxel as stored, so it has to agree with datatype. niupdate took datatype from eltype(R) and bitpix from T, the NIVolume's first type parameter - which is the scaled type typeof(one(T)*1.0f0+1.0f0) that indexing returns after scl_slope/scl_inter, not the type on disk.

So every integer width other than 32 bits got a header contradicting itself: UInt8 wrote datatype 2 with bitpix 32, Int16 datatype 4 with bitpix 32, Int64 datatype 1024 with bitpix 32. Bool escapes through its own constructor, which keeps T = Bool, and the 32-bit types escape because the wrong answer happens to match. The keyword constructor already gets this right by passing one t to both; niupdate then overwrote it on every write.

Round-tripping through NIfTI.jl is unaffected, since niread reads datatype and ignores bitpix - the damage is to readers that trust bitpix, which is why it went unnoticed. It surfaced writing UInt8 brain masks for tools outside Julia.

Test covers all thirteen supported element types.