### PR TITLE
TagBot: trigger on the registration comment, not only on cron

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,28 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1


### PR DESCRIPTION
TagBot has missed five of the last releases. 0.5.7, 0.5.8, 0.5.9, 0.6.0 and 0.6.2 are all in the General registry with no git tag and no GitHub release, which is why the releases page still shows 0.6.1 as the latest version while Pkg happily installs 0.6.2.

The workflow's only trigger was an hourly cron. GitHub disables scheduled workflows in a repository after 60 days without activity, and TagBot's cron mode only looks back a few days, so any version registered during a dormant stretch is skipped and never picked up again. The v0.6.1 tag shows the pattern directly: it was created in December 2024 and its release notes are headed "Diff since v0.5.6", having jumped over the four versions registered in between.

Switching to the issue_comment trigger is the fix TagBot documents. Registrator comments on the repository when a version is registered, which runs the workflow immediately and does not depend on cron being alive. The actor guard keeps it to those comments and to manual runs, and the workflow_dispatch lookback input allows a wider backfill window when tags have to be recovered.

The explicit permissions block matches the current template and makes the write scope the tag push needs independent of the repository's default GITHUB_TOKEN permissions, which are read-only for many organisations now.

Existing tags are not backfilled by this change.