### PR TITLE
Project.toml: drop the superseded [extras] block, complete the compat…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,14 +10,10 @@ Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
+Base64 = "1"
 CodecZlib = "0.7"
 MappedArrays = "0.3,0.4"
+Mmap = "1"
 TranscodingStreams = "0.9, 0.10, 0.11"
-julia = "1.10, 1.11, 1.12"
+julia = "1.10"
 
-[extras]
-GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["GZip", "Test"]


### PR DESCRIPTION
… entries

A test/Project.toml has existed since eeb893c, and Pkg uses it in preference to [targets] whenever it is present. The [extras] and [targets] blocks have therefore been inert since then, and the GZip listed in them was never installed for a test run. Nothing in the repository references GZip outside those two lines; the gzip handling in src goes through CodecZlib and TranscodingStreams. Leaving that in place is worse than not having it, because it reads as the live declaration of the test dependencies while the real list sits in test/Project.toml.

Base64 and Mmap gain compat entries. They are the only dependencies without one, and tooling does not exempt standard libraries: Aqua's deps_compat check reports both as missing, since it exempts nothing that is not in an explicit ignore list. "1" is the value the rest of the ecosystem uses for these two. This constrains nothing that was not already constrained, because the julia entry decides which standard library ships.

The julia entry is collapsed to its meaning. Caret semantics make "1.10" cover everything below 2.0 on its own, so listing 1.11 and 1.12 alongside it added nothing; the registry already normalises the entry to "1.10.0 - 1". Written this way nobody has to append a version here for each Julia release.

No change to the supported version range, and the test dependencies resolve exactly as before.