### PR TITLE
CI: test the supported Julia range, update actions, drop dead cache i…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,17 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+permissions:
+  contents: read
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
@@ -10,6 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          # 'min' is the lower bound of the julia compat entry, which nothing
+          # verified before.
+          - 'min'
+          - 'lts'
           - '1'
           - 'nightly'
         os:
@@ -17,24 +31,15 @@ jobs:
           - macOS-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v2
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
-
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
…nputs

Coverage. The matrix tested '1' and 'nightly' only, so the julia = "1.10" lower bound in Project.toml was never exercised. Adding 'min' and 'lts' makes the compat entry mean something.

Dead cache configuration. The cache step still carried path, key and restore-keys from the actions/cache it replaced. julia-actions/cache accepts none of those three, so they were inert and only produced "unexpected input" warnings. The accompanying env.cache-name existed solely to build the key expression that went with them.

Action versions. actions/checkout v4 to v7 and codecov/codecov-action v5 to v7 are the current majors. setup-julia, cache, buildpkg, runtest and processcoverage were already on their current majors, except cache which moves from v2 to v3.

Triggers. push is limited to master and tags, which stops branch pushes and their pull request from each running the full matrix, and a concurrency group cancels superseded pull request runs. The workflow declares contents: read, since nothing here needs write.

The codecov step now passes CODECOV_TOKEN. The upload is unauthenticated without that secret, as it is today; fail_ci_if_error defaults to false, so a failed upload does not fail the job either way.