### PR TITLE
Juliac compat: Generate header read, write and byteswap field by field

### DIFF
--- a/src/NIfTI.jl
+++ b/src/NIfTI.jl
@@ -118,12 +118,11 @@ function NIVolume(
         error("Orientation parameters for Method 2 and Method 3 are mutually exclusive")
     end
 
-    if method3
-        if size(orientation) != (3, 4)
-            error("Orientation matrix must be of dimensions (3, 4)")
-        end
-    else
-        orientation = zeros(Float32, 3, 4)
+    # a new variable, not a reassignment of the keyword: a reassigned variable
+    # captured by the closures below would be boxed and lose its type
+    srow = orientation === nothing ? zeros(Float32, 3, 4) : orientation
+    if size(srow) != (3, 4)
+        error("Orientation matrix must be of dimensions (3, 4)")
     end
 
     if slice_start == 0 && slice_end == 0 && dim_info[3] != 0
@@ -131,7 +130,7 @@ function NIVolume(
         slice_end = size(raw, dim_info[3]) - 1
     end
 
-    NIVolume(NIfTI1Header(SIZEOF_HDR1, string_tuple(data_type, 10), string_tuple(db_name, 18), extents, session_error,
+    NIVolume(NIfTI1Header(SIZEOF_HDR1, string_tuple(data_type, Val(10)), string_tuple(db_name, Val(18)), extents, session_error,
             regular, to_dim_info(dim_info), to_dim_i16(size(raw)), intent_p1, intent_p2,
             intent_p3, intent_code, eltype_to_int16(t), nibitpix(t),
             slice_start, (qfac, voxel_size..., time_step, 0, 0, 0), 352,
@@ -141,10 +140,10 @@ function NIVolume(
             UInt8(slice_code),
             UInt8(xyzt_units),
             cal_max, cal_min, slice_duration,
-            toffset, glmax, glmin, string_tuple(descrip, 80), string_tuple(aux_file, 24), (method2 || method3),
+            toffset, glmax, glmin, string_tuple(descrip, Val(80)), string_tuple(aux_file, Val(24)), (method2 || method3),
             method3, quatern_b, quatern_c, quatern_d,
-            qoffset_x, qoffset_y, qoffset_z, (orientation[1, :]...,),
-            (orientation[2, :]...,), (orientation[3, :]...,), string_tuple(intent_name, 16), NP1_MAGIC), extensions, raw)
+            qoffset_x, qoffset_y, qoffset_z, ntuple(j -> srow[1, j], Val(4)),
+            ntuple(j -> srow[2, j], Val(4)), ntuple(j -> srow[3, j], Val(4)), string_tuple(intent_name, Val(16)), NP1_MAGIC), extensions, raw)
 end
 
 # Validates the header of a volume and updates it to match the volume's contents

--- a/src/headers.jl
+++ b/src/headers.jl
@@ -1,25 +1,36 @@
 
+# Reading, writing and byte swapping of a header are generated field by field
+# from the packed on-disk layout, so that none of them needs to iterate over
+# field names at run time. That keeps them free of dynamic dispatch, which is
+# what static compilation with `juliac --trim` requires.
 function define_packed(ty::DataType)
     packed_offsets = cumsum([sizeof(x) for x in ty.types])
     sz = pop!(packed_offsets)
     pushfirst!(packed_offsets, 0)
+    fields = 1:length(packed_offsets)
+    swaps = [T <: Number && sizeof(T) > 1 ? :(ntoh(getfield(hdr, $i))) :
+             T <: NTuple && sizeof(eltype(T)) > 1 ? :(map(ntoh, getfield(hdr, $i))) : nothing
+             for (i, T) in enumerate(ty.types)]
 
     @eval begin
         function Base.read(io::IO, ::Type{$ty})
-            bytes = read!(io, Array{UInt8}(undef, $sz...))
-            hdr = $(Expr(:new, ty, [:(unsafe_load(convert(Ptr{$(ty.types[i])}, pointer(bytes) + $(packed_offsets[i])))) for i = 1:length(packed_offsets)]...,))
-            if hdr.sizeof_hdr == ntoh(Int32(348))
+            bytes = read!(io, Array{UInt8}(undef, $sz))
+            hdr = GC.@preserve bytes $(Expr(:new, ty, [:(unsafe_load(convert(Ptr{$(ty.types[i])}, pointer(bytes) + $(packed_offsets[i])))) for i in fields]...))
+            if hdr.sizeof_hdr == ntoh(Int32($sz))
                 return byteswap(hdr), true
             end
             hdr, false
         end
         function Base.write(io::IO, x::$ty)
-            bytes = UInt8[]
-            for name in fieldnames($ty)
-                append!(bytes, reinterpret(UInt8, [getfield(x, name)]))
+            bytes = Vector{UInt8}(undef, $sz)
+            GC.@preserve bytes begin
+                $([:(unsafe_store!(convert(Ptr{$(ty.types[i])}, pointer(bytes) + $(packed_offsets[i])), getfield(x, $i))) for i in fields]...)
             end
             write(io, bytes)
-            $sz
+        end
+        function byteswap(hdr::$ty)
+            $([:(setfield!(hdr, $i, $swap)) for (i, swap) in enumerate(swaps) if swap !== nothing]...)
+            hdr
         end
     end
     nothing
@@ -146,20 +157,6 @@ functions work generically across versions (e.g., `foo(::NIfTIHeader)`).
 See also: [`NIfTI1Header`](@ref), [`NIfTI2Header`](@ref)
 """
 const NIfTIHeader = Union{NIfTI1Header, NIfTI2Header}
-
-# byteswapping
-
-function byteswap(hdr::NIfTIHeader)
-    for fn in fieldnames(typeof(hdr))
-        val = getfield(hdr, fn)
-        if isa(val, Number) && sizeof(val) > 1
-            setfield!(hdr, fn, ntoh(val))
-        elseif isa(val, NTuple) && sizeof(eltype(val)) > 1
-            setfield!(hdr, fn, map(ntoh, val))
-        end
-    end
-    hdr
-end
 
 """
     NIfTI.slice_start(x)::Int

--- a/src/parsers.jl
+++ b/src/parsers.jl
@@ -197,12 +197,11 @@ function hdr_to_img(file::AbstractString)
     end
 end
 
-function string_tuple(x::String, n::Int)
-    a = codeunits(x)
-    padding = zeros(UInt8, n-length(a))
-    (a..., padding...)
+# A string as the zero-padded NTuple{n,UInt8} of a header field
+function string_tuple(x::AbstractString, ::Val{n}) where n
+    ncodeunits(x) <= n || throw(ArgumentError("\"$x\" is longer than the $n bytes of its header field"))
+    ntuple(i -> i <= ncodeunits(x) ? codeunit(x, i) : 0x00, Val(n))
 end
-string_tuple(x::AbstractString) = string_tuple(bytestring(x))
 
 const TIME_UNIT_MULTIPLIERS = [
     1000,   # NIfTI_UNITS_SEC

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,3 +165,22 @@ GC.gc() # closes mmapped files
         @test vol.raw == img
     end
 end
+
+@testset "header serialisation" begin
+    # written field by field: the same bytes as the fields concatenated
+    fieldbytes(hdr) = vcat([reinterpret(UInt8, [getfield(hdr, f)]) for f in fieldnames(typeof(hdr))]...)
+    nifti2 = joinpath(dirname(@__FILE__), "data/example_nifti2.nii.gz")
+    for hdr in (niread(GZIPPED_NII).header, niread(nifti2).header, NIVolume(rand(Float32, 4, 3, 2); descrip="described").header)
+        io = IOBuffer()
+        @test write(io, hdr) == hdr.sizeof_hdr
+        @test take!(io) == fieldbytes(hdr)
+        # a byte swapped header is recognised as such and reads back as the original
+        swapped = NIfTI.byteswap(deepcopy(hdr))
+        @test swapped.sizeof_hdr == bswap(hdr.sizeof_hdr)
+        write(io, swapped)
+        back, was_swapped = read(IOBuffer(take!(io)), typeof(hdr))
+        @test was_swapped
+        @test all(getfield(back, f) == getfield(hdr, f) for f in fieldnames(typeof(hdr)))
+    end
+    @test_throws ArgumentError NIVolume(zeros(2, 2); descrip=repeat("x", 81))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,4 +183,6 @@ end
         @test all(getfield(back, f) == getfield(hdr, f) for f in fieldnames(typeof(hdr)))
     end
     @test_throws ArgumentError NIVolume(zeros(2, 2); descrip=repeat("x", 81))
+    @test_throws ErrorException NIVolume(zeros(2, 2); orientation=zeros(Float32, 4, 4))
+    @test NIVolume(zeros(2, 2); orientation=Float32[1 0 0 0; 0 1 0 0; 0 0 1 0]).header.srow_x == (1, 0, 0, 0)
 end


### PR DESCRIPTION
**This is still experimental**

Reading a header was already generated from the packed layout; writing and byte swapping iterated over field names at run time. Both are now generated the same way, string fields are built with a Val length instead of a splat, and the orientation keyword is no longer reassigned, which boxed it in the closures. None of this changes a written byte: the new test compares the output with the fields concatenated.

Two things fell out of it. A byte swapped NIfTI-2 header was not recognised, since the check compared with 348 for both header types; it now compares with the size of the header being read. And the buffer behind the unsafe loads and stores is kept alive with 

The point is static compilation: with this, a program that builds a NIVolume, writes it and reads its header back compiles with juliac --trim (Julia 1.13), where it failed the verifier before. niread stays dynamic by design, since its element type comes from the file.